### PR TITLE
Add clang and gcc support, as well as DEBUG make option

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -13,9 +13,6 @@ MANPREFIX = ${PREFIX}/share/man
 # flags
 CPPFLAGS = -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_XOPEN_SOURCE=700 -D_POSIX_C_SOURCE=200809L -DVERSION=\"${SRCVERSION}\"
 CFLAGS  = -std=c99 -pedantic -Wall -Os ${INCS} ${CPPFLAGS}
-#CFLAGS  = -g -std=c99 -pedantic -Wall -Wextra -O3 ${INCS} ${CPPFLAGS} -flto -fsanitize=address,undefined,leak
 LDFLAGS =
-#LDFLAGS = -g ${CFLAGS}
 
 # compiler and linker
-CC = cc


### PR DESCRIPTION
compiling would now look like:
```
CC=clang DEBUG=true make
```
if you want to not use debug, you don't have to say ``DEBUG=false``, you just do 
```
CC=clang make
```

The extra flags are for the developer's safety. UBSan, ASan, etc are really nice. Let me know if something doesn't work.